### PR TITLE
add bonds sell below 1 peg test

### DIFF
--- a/contracts/treasury/BondManager.sol
+++ b/contracts/treasury/BondManager.sol
@@ -186,6 +186,15 @@ contract BondManager is
         SyntheticToken syntheticToken = SyntheticToken(syntheticTokenAddress); // trusted address since this is a managedToken
         SyntheticToken bondToken =
             SyntheticToken(bondIndex[syntheticTokenAddress]);
+			
+        uint256 underlyingUnit =
+            tokenManager.oneUnderlyingUnit(syntheticTokenAddress);
+        uint256 bondPrice = bondPriceUndPerUnitSyn(syntheticTokenAddress);
+        require(
+            bondPrice > underlyingUnit,
+            "BondManager: Synthetic price is not eligible for bond redemption"
+        );
+		
         uint256 amount =
             Math.min(syntheticToken.balanceOf(address(this)), amountOfBondsIn);
         require(

--- a/contracts/treasury/BondManager.sol
+++ b/contracts/treasury/BondManager.sol
@@ -90,7 +90,7 @@ contract BondManager is
     /// This is the price of synthetic in underlying (und / syn)
     /// but corrected for bond mechanics, i.e. max of oracle / current uniswap price
     /// @param syntheticTokenAddress The address of the synthetic token
-    /// @return The price of one unit (e.g. BTC, ETH, etc.) syn token in underlying token (e.g. sat, wei, etc)
+    /// @return The price of one unit (e.g. KBTC) syn token in underlying token (e.g. WBTC)
     /// @dev Fails if the token is not managed
     function bondPriceUndPerUnitSyn(address syntheticTokenAddress)
         public

--- a/test/treasury/BondManager.ts
+++ b/test/treasury/BondManager.ts
@@ -424,6 +424,14 @@ describe("BondManager", () => {
     describe("when there's enough BondManager balance, bonds are approved", () => {
       it("burns the bonds and transfers synthetic", async () => {
         await setupUniswap();
+        await router.swapExactTokensForTokens(
+          123,
+          0,
+          [underlying.address, synthetic.address],
+          op.address,
+          (await now()) + 1800
+        );
+		
         const amount = 12345;
         await bond.approve(manager.address, amount);
         await expect(manager.sellBonds(synthetic.address, amount, amount))
@@ -455,6 +463,13 @@ describe("BondManager", () => {
     describe("when there's not enough balance", () => {
       it("fails", async () => {
         await setupUniswap();
+        await router.swapExactTokensForTokens(
+          123,
+          0,
+          [underlying.address, synthetic.address],
+          op.address,
+          (await now()) + 1800
+        );
         const managerBalance = await synthetic.balanceOf(manager.address);
         const opBalance = await bond.balanceOf(op.address);
         assert(managerBalance < opBalance);
@@ -474,6 +489,13 @@ describe("BondManager", () => {
     describe("when bonds are not approved", () => {
       it("fails", async () => {
         await setupUniswap();
+        await router.swapExactTokensForTokens(
+          123,
+          0,
+          [underlying.address, synthetic.address],
+          op.address,
+          (await now()) + 1800
+        );
         const amount = 12345;
         await bond.approve(manager.address, amount - 1);
         await expect(

--- a/test/treasury/BondManager.ts
+++ b/test/treasury/BondManager.ts
@@ -434,7 +434,7 @@ describe("BondManager", () => {
       });
     });
     describe("when price is below 1", () => {
-      it("still sells below one", async () => {
+      it("redemption will fail", async () => {
         await setupUniswap();
         await router.swapExactTokensForTokens(
           BigNumber.from(10).pow(SYNTHETIC_DECIMALS),
@@ -445,11 +445,11 @@ describe("BondManager", () => {
         );
 		const amount = 12345;
         await bond.approve(manager.address, amount);
-        await expect(manager.sellBonds(synthetic.address, amount, amount))
-          .to.emit(bond, "Transfer")
-          .withArgs(op.address, ethers.constants.AddressZero, amount)
-          .and.to.emit(synthetic, "Transfer")
-          .withArgs(manager.address, op.address, amount);
+        await expect(
+		  manager.sellBonds(synthetic.address, amount, amount)
+        ).to.be.revertedWith(
+          "BondManager: Synthetic price is not eligible for bond redemption"
+        );
       });
     });
     describe("when there's not enough balance", () => {

--- a/test/treasury/BondManager.ts
+++ b/test/treasury/BondManager.ts
@@ -433,8 +433,26 @@ describe("BondManager", () => {
           .withArgs(manager.address, op.address, amount);
       });
     });
-
-    describe("when there's not enough balace", () => {
+    describe("when price is below 1", () => {
+      it("still sells below one", async () => {
+        await setupUniswap();
+        await router.swapExactTokensForTokens(
+          BigNumber.from(10).pow(SYNTHETIC_DECIMALS),
+          0,
+          [synthetic.address, underlying.address],
+          op.address,
+          (await now()) + 1800
+        );
+		const amount = 12345;
+        await bond.approve(manager.address, amount);
+        await expect(manager.sellBonds(synthetic.address, amount, amount))
+          .to.emit(bond, "Transfer")
+          .withArgs(op.address, ethers.constants.AddressZero, amount)
+          .and.to.emit(synthetic, "Transfer")
+          .withArgs(manager.address, op.address, amount);
+      });
+    });
+    describe("when there's not enough balance", () => {
       it("fails", async () => {
         await setupUniswap();
         const managerBalance = await synthetic.balanceOf(manager.address);


### PR DESCRIPTION
Added a test to show bonds can be sold below PEG 1:1

Changed the test to fail when below PEG

Added fix with use of the `bondPriceUndPerUnitSyn` method to check for current PEG